### PR TITLE
Update the visual style of Rekor entries

### DIFF
--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -1,0 +1,289 @@
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import {
+	Accordion,
+	AccordionDetails as MuiAccordionDetails,
+	AccordionSummary,
+	Divider,
+	DividerProps,
+	Grid,
+	Paper,
+	styled,
+	Typography,
+} from "@mui/material";
+import { Box } from "@mui/system";
+import { dump, load } from "js-yaml";
+import moment from "moment";
+import { Convert } from "pvtsutils";
+import { ReactNode } from "react";
+import Highlight from "react-highlight";
+import { LogEntry } from "../api/generated";
+
+const DUMP_OPTIONS: jsyaml.DumpOptions = {
+	replacer: (key, value) => {
+		if (Convert.isBase64(value)) {
+			try {
+				return load(window.atob(value));
+			} catch (e) {
+				return value;
+			}
+		}
+		return value;
+	},
+};
+
+export function Card({
+	title,
+	content,
+	dividerSx = {},
+}: {
+	title: ReactNode;
+	content: ReactNode;
+	dividerSx?: DividerProps["sx"];
+}) {
+	return (
+		<div
+			style={{
+				display: "flex",
+			}}
+		>
+			<Divider
+				orientation="vertical"
+				flexItem
+				sx={{
+					mx: 1,
+					...dividerSx,
+				}}
+			/>
+			<Box>
+				<Typography
+					variant="button"
+					component="h3"
+				>
+					{title}
+				</Typography>
+				<Typography
+					variant="body2"
+					component="p"
+					sx={{
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "start",
+					}}
+				>
+					{content}
+				</Typography>
+			</Box>
+		</div>
+	);
+}
+
+const SecondarySpan = styled("span")(({ theme }) => ({
+	color: theme.palette.info.main,
+	paddingInlineStart: theme.spacing(1),
+}));
+
+const AccordionDetails = styled(MuiAccordionDetails)({
+	padding: 0,
+});
+
+function RelativeDate({ date }: { date: Date }) {
+	return (
+		<>
+			{moment().to(date)}
+			<SecondarySpan>({moment(date).format()})</SecondarySpan>
+		</>
+	);
+}
+
+/**
+ * Return a parsed JSON object of the provided content.
+ * If an error occurs, the provided content is returned as a raw string.
+ */
+function tryJSONParse(content?: string): unknown {
+	if (!content) {
+		return content;
+	}
+	try {
+		return JSON.parse(content);
+	} catch (e) {
+		return content;
+	}
+}
+
+export function Entry({ entry }: { entry: LogEntry }) {
+	const [uuid, obj] = Object.entries(entry)[0];
+
+	const body = JSON.parse(window.atob(obj.body)) as {
+		kind: string;
+		spec: string;
+	};
+
+	// Extract the JSON payload of the attestation. Some attestations appear to be
+	// double Base64 encoded. This loop will attempt to extract the content, with
+	// a max depth as a safety gap.
+	let rawAttestation = obj.attestation?.data as string | undefined;
+	for (let i = 0; Convert.isBase64(rawAttestation) && i < 3; i++) {
+		rawAttestation = window.atob(rawAttestation);
+	}
+	const attestation = tryJSONParse(rawAttestation);
+
+	return (
+		<Paper sx={{ my: 1, p: 1 }}>
+			<Typography
+				variant="h5"
+				component="h2"
+				sx={{
+					overflow: "hidden",
+					textOverflow: "ellipsis",
+				}}
+			>
+				Entry UUID: {uuid}
+			</Typography>
+			<Divider
+				flexItem
+				sx={{ my: 1 }}
+			/>
+			<Grid
+				container
+				sx={{ mb: 1 }}
+				rowSpacing={1}
+			>
+				<Grid
+					item
+					xs={6}
+					sm={3}
+					md={2}
+				>
+					<Card
+						title="Type"
+						content={body.kind}
+						dividerSx={{
+							display: "none",
+						}}
+					/>
+				</Grid>
+				<Grid
+					item
+					xs={6}
+					sm={3}
+					md={2}
+				>
+					<Card
+						title="Log Index"
+						content={obj.logIndex}
+					/>
+				</Grid>
+				<Grid
+					item
+					xs={6}
+					sm={3}
+					md={2}
+				>
+					<Card
+						title="Verification"
+						content={
+							obj.verification ? (
+								<>
+									<CheckCircleOutlinedIcon color="success" />
+									<SecondarySpan color="success">Found</SecondarySpan>
+								</>
+							) : (
+								<>
+									<ErrorOutlineIcon color="error" />
+									<SecondarySpan>Missing</SecondarySpan>
+								</>
+							)
+						}
+						dividerSx={{
+							display: {
+								xs: "none",
+								sm: "block",
+							},
+						}}
+					/>
+				</Grid>
+				<Grid
+					item
+					xs={6}
+					sm={3}
+					md={2}
+				>
+					<Card
+						title="Attestation"
+						content={
+							attestation ? (
+								<>
+									<CheckCircleOutlinedIcon color="info" />
+									<SecondarySpan>Found</SecondarySpan>
+								</>
+							) : (
+								<>
+									<InfoOutlinedIcon color="info" />
+									<SecondarySpan>None</SecondarySpan>
+								</>
+							)
+						}
+					/>
+				</Grid>
+				<Grid
+					item
+					xs={12}
+					md={4}
+				>
+					<Card
+						title="Integrated time"
+						content={
+							<span>
+								<RelativeDate date={new Date(obj.integratedTime * 1000)} />
+							</span>
+						}
+						dividerSx={{
+							display: {
+								xs: "none",
+								md: "block",
+							},
+						}}
+					/>
+				</Grid>
+			</Grid>
+			<Highlight className="yaml">{dump(body.spec, DUMP_OPTIONS)}</Highlight>
+			<Box sx={{ mt: 1 }}>
+				<>
+					{attestation && (
+						<Accordion disableGutters>
+							<AccordionSummary
+								expandIcon={<ExpandMoreIcon />}
+								aria-controls="panel2a-content"
+								id="panel2a-header"
+							>
+								<Typography>Attestation</Typography>
+							</AccordionSummary>
+							<AccordionDetails>
+								<Highlight className="yaml">{dump(attestation)}</Highlight>
+							</AccordionDetails>
+						</Accordion>
+					)}
+					{obj.verification && (
+						<Accordion disableGutters>
+							<AccordionSummary
+								expandIcon={<ExpandMoreIcon />}
+								aria-controls="panel2a-content"
+								id="panel2a-header"
+							>
+								<Typography>Verification</Typography>
+							</AccordionSummary>
+							<AccordionDetails>
+								<Highlight className="yaml">{dump(obj.verification)}</Highlight>
+							</AccordionDetails>
+						</Accordion>
+					)}
+				</>
+			</Box>
+		</Paper>
+	);
+}

--- a/src/modules/theme/theme.ts
+++ b/src/modules/theme/theme.ts
@@ -3,8 +3,14 @@ import { createTheme } from "@mui/material/styles";
 export const REKOR_SEARCH_THEME = createTheme({
 	typography: {
 		fontFamily: ["Inter", "sans-serif"].join(","),
+		h4: {
+			fontWeight: 300,
+			fontSize: "1.5rem",
+			color: "#444444",
+		},
 		h5: {
 			fontWeight: 300,
+			fontSize: "0.9rem",
 			color: "#444444",
 		},
 	},

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import {
 	Card,
 	CardActionArea,
 	Container,
+	CssBaseline,
 	ThemeProvider,
 	Typography,
 } from "@mui/material";
@@ -28,6 +29,7 @@ const Home: NextPage = () => {
 			</Head>
 
 			<ThemeProvider theme={REKOR_SEARCH_THEME}>
+				<CssBaseline />
 				<Container
 					sx={{
 						mt: 3,
@@ -49,7 +51,7 @@ const Home: NextPage = () => {
 								alignItems: "center",
 								gap: 2,
 							}}
-							variant="h5"
+							variant="h4"
 							component="h1"
 						>
 							<Image

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,7 @@ a {
 pre {
 	white-space: pre-wrap;
 	word-wrap: break-word;
+	margin: 0;
 }
 
 code {


### PR DESCRIPTION
### Before

<img width="1109" alt="Screen Shot 2022-05-20 at 5 43 18 PM" src="https://user-images.githubusercontent.com/1692704/169627631-b53a2e35-2cf4-42e5-a7a0-82adbc99c7dc.png">

### After

<img width="1107" alt="Screen Shot 2022-05-20 at 5 43 45 PM" src="https://user-images.githubusercontent.com/1692704/169627647-2176f86c-18ab-4259-a8af-62a889a82e3b.png">

Part of #5 

Next step will be decoding specific fields for a integrated type!