### PR TITLE
Add support for Fulcio X509 extensions

### DIFF
--- a/src/modules/components/HashedRekord.tsx
+++ b/src/modules/components/HashedRekord.tsx
@@ -20,7 +20,10 @@ export function HashedRekordViewer({
 	};
 	if (certContent.includes("BEGIN CERTIFICATE")) {
 		publicKey.title = "Public Key Certificate";
-		publicKey.content = dump(decodex509(certContent));
+		publicKey.content = dump(decodex509(certContent), {
+			noArrayIndent: true,
+			lineWidth: -1,
+		});
 	}
 
 	return (

--- a/src/modules/x509/constants.ts
+++ b/src/modules/x509/constants.ts
@@ -1,0 +1,13 @@
+import { KeyUsageFlags } from "@peculiar/x509";
+
+export const KEY_USAGE_NAMES: Record<KeyUsageFlags, string> = {
+	[KeyUsageFlags.digitalSignature]: "Digital Signature",
+	[KeyUsageFlags.nonRepudiation]: "Non Repudiation",
+	[KeyUsageFlags.keyEncipherment]: "Key Encipherment",
+	[KeyUsageFlags.dataEncipherment]: "Data Encipherment",
+	[KeyUsageFlags.keyAgreement]: "Key Agreement",
+	[KeyUsageFlags.keyCertSign]: "Key Certificate Sign",
+	[KeyUsageFlags.cRLSign]: "Certificate Revocation List Sign",
+	[KeyUsageFlags.encipherOnly]: "Encipher Only",
+	[KeyUsageFlags.decipherOnly]: "Decipher Only",
+};

--- a/src/modules/x509/decode.ts
+++ b/src/modules/x509/decode.ts
@@ -1,18 +1,30 @@
-import {
-	AuthorityKeyIdentifierExtension,
-	BasicConstraintsExtension,
-	ExtendedKeyUsageExtension,
-	KeyUsagesExtension,
-	SubjectAlternativeNameExtension,
-	SubjectKeyIdentifierExtension,
-	X509Certificate,
-} from "@peculiar/x509";
+import { X509Certificate } from "@peculiar/x509";
 import { toRelativeDateString } from "../utils/date";
+import { EXTENSIONS_CONFIG } from "./extensions";
 
-const UTF_8_DECODER = new TextDecoder("utf-8");
+function bufferToHex(buffer: ArrayBuffer): string {
+	return [...new Uint8Array(buffer)]
+		.map(x => x.toString(16).padStart(2, "0"))
+		.join(":");
+}
 
 export function decodex509(rawCertificate: string) {
 	const cert = new X509Certificate(rawCertificate);
+
+	const decodedExtensions: Record<string, {}> = {};
+	for (const extension of cert.extensions) {
+		const criticalLabel = extension.critical ? " (critical)" : "";
+
+		const config = EXTENSIONS_CONFIG[extension.type];
+		if (config) {
+			decodedExtensions[`${config.name}${criticalLabel}`] =
+				config.toJSON(extension);
+		} else {
+			const text = bufferToHex(extension.value);
+			decodedExtensions[`${extension.type}${criticalLabel}`] = text;
+		}
+	}
+
 	const decodedCert = {
 		data: {
 			"Serial Number": `0x${cert.serialNumber}`,
@@ -26,82 +38,7 @@ export function decodex509(rawCertificate: string) {
 			Algorithm: cert.publicKey.algorithm,
 			Subject: cert.subjectName,
 		},
-		"X509v3 extensions": {} as any,
+		"X509v3 extensions": decodedExtensions,
 	};
-	for (const ext of cert.extensions) {
-		switch (ext.type) {
-			case "2.5.29.17": {
-				const sub = new SubjectAlternativeNameExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Subject Alternative Name: ${ext.critical ? "critical" : ""}`
-				] = {
-					email: sub.email,
-				};
-				break;
-			}
-			case "2.5.29.15": {
-				const usage = new KeyUsagesExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Key Usage: ${ext.critical ? "critical" : ""}`
-				] = [
-					usage.usages === 1 ? "Digital Signature" : usage.usages.toString(),
-				];
-				break;
-			}
-			case "2.5.29.37": {
-				const key = new ExtendedKeyUsageExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Extended Key Usage: ${ext.critical ? "critical" : ""}`
-				] = key.usages.map(code => {
-					switch (code) {
-						case "1.3.6.1.5.5.7.3.3":
-							return "Code Signing";
-						default:
-							return code;
-					}
-				});
-				break;
-			}
-			case "2.5.29.19": {
-				const constraints = new BasicConstraintsExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Basic Constraints: ${ext.critical ? "critical" : ""}`
-				] = {
-					CA: constraints.ca,
-				};
-				break;
-			}
-			case "2.5.29.14": {
-				const subjectKey = new SubjectKeyIdentifierExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Subject Key Identifier: ${ext.critical ? "critical" : ""}`
-				] = [
-					subjectKey.keyId
-						.match(/.{1,2}/g)
-						?.join(":")
-						.toUpperCase(),
-				];
-				break;
-			}
-			case "2.5.29.35": {
-				const authorityKey = new AuthorityKeyIdentifierExtension(ext.rawData);
-				decodedCert["X509v3 extensions"][
-					`X509v3 Authority Key Identifier: ${ext.critical ? "critical" : ""}`
-				] = {
-					keyid: authorityKey.keyId
-						?.match(/.{1,2}/g)
-						?.join(":")
-						.toUpperCase(),
-					certid: authorityKey.certId,
-				};
-				break;
-			}
-			default:
-				const text = UTF_8_DECODER.decode(ext.value);
-				decodedCert["X509v3 extensions"][
-					`${ext.type}: ${ext.critical ? "critical" : ""}`
-				] = [text];
-		}
-	}
 	return decodedCert;
 }

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -1,0 +1,123 @@
+import {
+	AuthorityKeyIdentifierExtension,
+	BasicConstraintsExtension,
+	ExtendedKeyUsageExtension,
+	Extension,
+	KeyUsageFlags,
+	KeyUsagesExtension,
+	SubjectAlternativeNameExtension,
+	SubjectKeyIdentifierExtension,
+} from "@peculiar/x509";
+import { KEY_USAGE_NAMES } from "./constants";
+
+interface ExtensionConfig {
+	name: string;
+	toJSON: (rawExtension: Extension) => {};
+}
+
+const UTF_8_DECODER = new TextDecoder("utf-8");
+function textDecoder(rawExtension: Extension) {
+	return UTF_8_DECODER.decode(rawExtension.value);
+}
+
+/**
+ * Map from OID to Extension
+ */
+export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
+	"2.5.29.14": {
+		name: "X509v3 Subject Key Identifier",
+		toJSON(rawExtension: Extension) {
+			const ext = new SubjectKeyIdentifierExtension(rawExtension.rawData);
+			return [
+				ext.keyId
+					.match(/.{1,2}/g)
+					?.join(":")
+					.toUpperCase(),
+			];
+		},
+	},
+	"2.5.29.15": {
+		name: "X509v3 Key Usage",
+		toJSON(rawExtension: Extension) {
+			const ext = new KeyUsagesExtension(rawExtension.rawData);
+			const usages: string[] = [];
+
+			const keys = Object.keys(KEY_USAGE_NAMES) as unknown as KeyUsageFlags[];
+			for (const key of keys) {
+				if (ext.usages & key) {
+					usages.push(KEY_USAGE_NAMES[key]);
+				}
+			}
+			return usages;
+		},
+	},
+	"2.5.29.17": {
+		name: "X509v3 Subject Alternative Name",
+		toJSON(rawExtension: Extension) {
+			return new SubjectAlternativeNameExtension(rawExtension.rawData).toJSON();
+		},
+	},
+	"2.5.29.19": {
+		name: "X509v3 Basic Constraints",
+		toJSON(rawExtension: Extension) {
+			const ext = new BasicConstraintsExtension(rawExtension.rawData);
+			return {
+				CA: ext.ca,
+			};
+		},
+	},
+	"2.5.29.35": {
+		name: "X509v3 Authority Key Identifier",
+		toJSON(rawExtension: Extension) {
+			const ext = new AuthorityKeyIdentifierExtension(rawExtension.rawData);
+			return {
+				keyid: ext.keyId
+					?.match(/.{1,2}/g)
+					?.join(":")
+					.toUpperCase(),
+				certid: ext.certId,
+			};
+		},
+	},
+	"2.5.29.37": {
+		name: "X509v3 Extended Key Usage",
+		toJSON(rawExtension: Extension) {
+			const ext = new ExtendedKeyUsageExtension(rawExtension.rawData);
+			return ext.usages.map(code => {
+				switch (code) {
+					case "1.3.6.1.5.5.7.3.3":
+						return "Code Signing";
+					default:
+						return code;
+				}
+			});
+		},
+	},
+	/**
+	 * Fulcio OIDs are based on https://github.com/sigstore/fulcio/tree/main/pkg/ca/x509ca/extensions.go
+	 */
+	"1.3.6.1.4.1.57264.1.1": {
+		name: "Fulcio Issuer",
+		toJSON: textDecoder,
+	},
+	"1.3.6.1.4.1.57264.1.2": {
+		name: "Fulcio GitHub Workflow Trigger",
+		toJSON: textDecoder,
+	},
+	"1.3.6.1.4.1.57264.1.3": {
+		name: "Fulcio GitHub Workflow SHA",
+		toJSON: textDecoder,
+	},
+	"1.3.6.1.4.1.57264.1.4": {
+		name: "Fulcio GitHub Workflow Name",
+		toJSON: textDecoder,
+	},
+	"1.3.6.1.4.1.57264.1.5": {
+		name: "Fulcio GitHub Workflow Repository",
+		toJSON: textDecoder,
+	},
+	"1.3.6.1.4.1.57264.1.6": {
+		name: "Fulcio GitHub Workflow Ref",
+		toJSON: textDecoder,
+	},
+};


### PR DESCRIPTION
- Move the extension parsing to a dedicated file
- Add support for Fulcio's extensions
- Change a few YAML rendering settings to make the cert a bit more compact

## Example 1 (https://rekor.tlog.dev/?logIndex=2541703)

Before:
![Screen Shot 2022-06-02 at 4 11 10 PM](https://user-images.githubusercontent.com/1692704/171752832-e66bfae3-2485-4d71-8dc7-74c049e0276d.png)

After:
![Screen Shot 2022-06-02 at 4 09 26 PM](https://user-images.githubusercontent.com/1692704/171752751-f7ee93cf-37b9-4316-8ff7-410e4451bebc.png)

## Example 2 (https://rekor.tlog.dev/?logIndex=2529760)

Before:
![Screen Shot 2022-06-02 at 4 13 41 PM](https://user-images.githubusercontent.com/1692704/171753029-d2849db2-4e00-480f-b895-baf9c2c4de5c.png)

After:
![Screen Shot 2022-06-02 at 4 14 18 PM](https://user-images.githubusercontent.com/1692704/171753069-41cf6901-60ef-4a32-a37c-c223b03ba10f.png)

