### PR TITLE
Add links for uuid, hash & log index

### DIFF
--- a/src/modules/api/rekor_api.ts
+++ b/src/modules/api/rekor_api.ts
@@ -82,7 +82,7 @@ function retrieveEntriesFromIndex(
 	return retrieveIndex(query).pipe(
 		map((logIndexes: string[]) => ({
 			totalCount: logIndexes.length,
-			indexes: logIndexes.slice(0, 20),
+			indexes: logIndexes.slice(0, 5),
 		})),
 		switchMap(log => {
 			if (log.indexes.length) {

--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -6,12 +6,14 @@ import {
 	Divider,
 	DividerProps,
 	Grid,
+	Link,
 	Paper,
 	styled,
 	Typography,
 } from "@mui/material";
 import { Box } from "@mui/system";
 import { dump, load } from "js-yaml";
+import NextLink from "next/link";
 import { Convert } from "pvtsutils";
 import { ReactNode } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -139,7 +141,13 @@ export function Entry({ entry }: { entry: LogEntry }) {
 					textOverflow: "ellipsis",
 				}}
 			>
-				Entry UUID: {uuid}
+				Entry UUID:{" "}
+				<NextLink
+					href={`/?uuid=${uuid}`}
+					passHref
+				>
+					<Link>{uuid}</Link>
+				</NextLink>
 			</Typography>
 			<Divider
 				flexItem
@@ -170,7 +178,14 @@ export function Entry({ entry }: { entry: LogEntry }) {
 				>
 					<Card
 						title="Log Index"
-						content={obj.logIndex}
+						content={
+							<NextLink
+								href={`/?logIndex=${obj.logIndex}`}
+								passHref
+							>
+								<Link>{obj.logIndex}</Link>
+							</NextLink>
+						}
 					/>
 				</Grid>
 				<Grid

--- a/src/modules/components/HashedRekord.tsx
+++ b/src/modules/components/HashedRekord.tsx
@@ -1,5 +1,6 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Link, Typography } from "@mui/material";
 import { dump } from "js-yaml";
+import NextLink from "next/link";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { HashedRekord } from "../api/generated/types/hashedrekord";
@@ -32,14 +33,21 @@ export function HashedRekordViewer({
 				variant="h5"
 				sx={{ py: 1 }}
 			>
-				Hash
+				<NextLink
+					href={`/?hash=${hashedRekord.data.hash?.algorithm}:${hashedRekord.data.hash?.value}`}
+					passHref
+				>
+					<Link>Hash</Link>
+				</NextLink>
 			</Typography>
+
 			<SyntaxHighlighter
 				language="text"
 				style={atomDark}
 			>
 				{`${hashedRekord.data.hash?.algorithm}:${hashedRekord.data.hash?.value}`}
 			</SyntaxHighlighter>
+
 			<Typography
 				variant="h5"
 				sx={{ py: 1 }}


### PR DESCRIPTION
Adds a few links, and also a fly-by change to limit the number of results returned to 5. Given each record is already pretty big - this seems more manageable. We could consider adding pagination later if we decide it makes sense.

Fixes #27 