### PR TITLE
Also parse certs in intoto entries

### DIFF
--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -20,8 +20,10 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { LogEntry } from "../api/generated";
 import { HashedRekord } from "../api/generated/types/hashedrekord";
+import { Intoto } from "../api/generated/types/intoto";
 import { toRelativeDateString } from "../utils/date";
 import { HashedRekordViewer } from "./HashedRekord";
+import { IntotoViewer } from "./Intoto";
 
 const DUMP_OPTIONS: jsyaml.DumpOptions = {
 	replacer: (key, value) => {
@@ -125,6 +127,9 @@ export function Entry({ entry }: { entry: LogEntry }) {
 	switch (body.kind) {
 		case "hashedrekord":
 			parsed = <HashedRekordViewer hashedRekord={body.spec as HashedRekord} />;
+			break;
+		case "intoto":
+			parsed = <IntotoViewer intoto={body.spec as Intoto} />;
 			break;
 	}
 

--- a/src/modules/components/Intoto.tsx
+++ b/src/modules/components/Intoto.tsx
@@ -1,0 +1,77 @@
+import { Box, Link, Typography } from "@mui/material";
+import { dump } from "js-yaml";
+import NextLink from "next/link";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { Intoto } from "../api/generated/types/intoto";
+import { decodex509 } from "../x509/decode";
+
+export function IntotoViewer({
+	intoto,
+}: {
+	intoto: Intoto;
+}) {
+	const certContent = window.atob(
+		intoto.publicKey || ""
+	);
+
+	const publicKey = {
+		title: "Public Key",
+		content: certContent,
+	};
+	if (certContent.includes("BEGIN CERTIFICATE")) {
+		publicKey.title = "Public Key Certificate";
+		publicKey.content = dump(decodex509(certContent), {
+			noArrayIndent: true,
+			lineWidth: -1,
+		});
+	}
+
+	return (
+		<Box>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				<NextLink
+					href={`/?hash=${intoto.content.hash?.algorithm}:${intoto.content.hash?.value}`}
+					passHref
+				>
+					<Link>Hash</Link>
+				</NextLink>
+			</Typography>
+
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{`${intoto.content.hash?.algorithm}:${intoto.content.hash?.value}`}
+			</SyntaxHighlighter>
+
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				Signature
+			</Typography>
+			<SyntaxHighlighter
+				language="text"
+				style={atomDark}
+			>
+				{intoto.publicKey || ""}
+			</SyntaxHighlighter>
+			<Typography
+				variant="h5"
+				sx={{ py: 1 }}
+			>
+				{publicKey.title}
+			</Typography>
+			<SyntaxHighlighter
+				language="yaml"
+				style={atomDark}
+			>
+				{publicKey.content}
+			</SyntaxHighlighter>
+		</Box>
+	);
+}

--- a/src/modules/components/Intoto.tsx
+++ b/src/modules/components/Intoto.tsx
@@ -6,14 +6,8 @@ import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { Intoto } from "../api/generated/types/intoto";
 import { decodex509 } from "../x509/decode";
 
-export function IntotoViewer({
-	intoto,
-}: {
-	intoto: Intoto;
-}) {
-	const certContent = window.atob(
-		intoto.publicKey || ""
-	);
+export function IntotoViewer({ intoto }: { intoto: Intoto }) {
+	const certContent = window.atob(intoto.publicKey || "");
 
 	const publicKey = {
 		title: "Public Key",

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -16,7 +16,7 @@ interface ExtensionConfig {
 }
 
 const UTF_8_DECODER = new TextDecoder("utf-8");
-function textDecoder(rawExtension: Extension) {
+function textDecoder(rawExtension: Extension): string {
 	return UTF_8_DECODER.decode(rawExtension.value);
 }
 
@@ -94,7 +94,7 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 		},
 	},
 	/**
-	 * Fulcio OIDs are based on https://github.com/sigstore/fulcio/tree/main/pkg/ca/x509ca/extensions.go
+	 * Fulcio OIDs are based on https://github.com/sigstore/fulcio/blob/main/pkg/ca/extensions.go
 	 */
 	"1.3.6.1.4.1.57264.1.1": {
 		name: "OIDC Issuer",


### PR DESCRIPTION
Currently: https://rekor.tlog.dev/?uuid=362f8ecba72f4326ec44bdec24f7cb2eef2b125e6390590bcaf6268d9b3833e0096381a1c2508eb2

This involves quite a bit of copying from `HashedRekord.tsx`, which means I probably want to make some kind of abstract thing that takes either `hashedRekord.signature.publicKey?.content` or `intoto.publicKey`, let me know if you think that's worth exploring more.