### PR TITLE
Feature: Configure Rekor's URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
 		"react-syntax-highlighter": "^15.5.0",
 		"rekor": "^0.0.7",
 		"sass": "^1.49.9",
-		"sharp": "^0.30.5",
-		"swr": "^2.0.0"
+		"sharp": "^0.30.5"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.20.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,6 @@ specifiers:
   rekor: ^0.0.7
   sass: ^1.49.9
   sharp: ^0.30.5
-  swr: ^2.0.0
   typescript: 4.6.2
 
 dependencies:
@@ -52,7 +51,6 @@ dependencies:
   rekor: 0.0.7
   sass: 1.57.1
   sharp: 0.30.7
-  swr: 2.0.0_react@18.2.0
 
 devDependencies:
   '@babel/core': 7.20.7
@@ -3100,16 +3098,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /swr/2.0.0_react@18.2.0:
-    resolution: {integrity: sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==}
-    engines: {pnpm: '7'}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-      use-sync-external-store: 1.2.0_react@18.2.0
-    dev: false
-
   /tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
     dependencies:
@@ -3225,14 +3213,6 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
-
-  /use-sync-external-store/1.2.0_react@18.2.0:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -1,0 +1,62 @@
+import {
+	createContext,
+	FunctionComponent,
+	PropsWithChildren,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+import { RekorClient } from "rekor";
+
+export interface RekorClientContext {
+	client: RekorClient;
+	baseUrl?: string;
+	setBaseUrl: (base: string | undefined) => void;
+}
+
+export const RekorClientContext = createContext<RekorClientContext | undefined>(
+	undefined
+);
+
+export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
+	children,
+}) => {
+	const [baseUrl, setBaseUrl] = useState<string>();
+
+	const context: RekorClientContext = useMemo(() => {
+		return {
+			client: new RekorClient({ BASE: baseUrl }),
+			baseUrl,
+			setBaseUrl,
+		};
+	}, [baseUrl]);
+
+	return (
+		<RekorClientContext.Provider value={context}>
+			{children}
+		</RekorClientContext.Provider>
+	);
+};
+
+export function useRekorClient(): RekorClient {
+	const ctx = useContext(RekorClientContext);
+
+	if (!ctx) {
+		throw new Error("Hook useRekorClient requires RekorClientContext.");
+	}
+
+	return ctx.client;
+}
+
+export function useRekorBaseUrl(): [
+	RekorClientContext["baseUrl"],
+	RekorClientContext["setBaseUrl"]
+] {
+	const ctx = useContext(RekorClientContext);
+
+	if (!ctx) {
+		throw new Error("Hook useRekorBaseUrl requires RekorClientContext.");
+	}
+
+	return [ctx.baseUrl, ctx.setBaseUrl];
+}

--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -142,12 +142,13 @@ export function Entry({ entry }: { entry: LogEntry }) {
 				}}
 			>
 				Entry UUID:{" "}
-				<NextLink
+				<Link
+					component={NextLink}
 					href={`/?uuid=${uuid}`}
 					passHref
 				>
-					<Link>{uuid}</Link>
-				</NextLink>
+					{uuid}
+				</Link>
 			</Typography>
 			<Divider
 				flexItem
@@ -179,12 +180,13 @@ export function Entry({ entry }: { entry: LogEntry }) {
 					<Card
 						title="Log Index"
 						content={
-							<NextLink
+							<Link
+								component={NextLink}
 								href={`/?logIndex=${obj.logIndex}`}
 								passHref
 							>
-								<Link>{obj.logIndex}</Link>
-							</NextLink>
+								{obj.logIndex}
+							</Link>
 						}
 					/>
 				</Grid>

--- a/src/modules/components/HashedRekord.tsx
+++ b/src/modules/components/HashedRekord.tsx
@@ -33,12 +33,13 @@ export function HashedRekordViewer({
 				variant="h5"
 				sx={{ py: 1 }}
 			>
-				<NextLink
+				<Link
+					component={NextLink}
 					href={`/?hash=${hashedRekord.data.hash?.algorithm}:${hashedRekord.data.hash?.value}`}
 					passHref
 				>
-					<Link>Hash</Link>
-				</NextLink>
+					Hash
+				</Link>
 			</Typography>
 
 			<SyntaxHighlighter

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -1,0 +1,70 @@
+import {
+	Box,
+	Button,
+	Divider,
+	Drawer,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { ChangeEventHandler, useCallback, useState } from "react";
+import { useRekorBaseUrl } from "../api/context";
+
+export function Settings({
+	open,
+	onClose,
+}: {
+	open: boolean;
+	onClose: () => void;
+}) {
+	const [baseUrl, setBaseUrl] = useRekorBaseUrl();
+	const [localBaseUrl, setLocalBaseUrl] = useState(baseUrl);
+
+	const handleChangeBaseUrl: ChangeEventHandler<
+		HTMLTextAreaElement | HTMLInputElement
+	> = useCallback(e => {
+		if (e.target.value.length === 0) {
+			setLocalBaseUrl(undefined);
+		} else {
+			setLocalBaseUrl(e.target.value);
+		}
+	}, []);
+
+	const onSave = useCallback(() => {
+		setBaseUrl(localBaseUrl);
+		onClose();
+	}, [localBaseUrl, setBaseUrl, onClose]);
+
+	return (
+		<Drawer
+			anchor={"right"}
+			open={open}
+			onClose={onClose}
+		>
+			<Box sx={{ width: 320 }}>
+				<Box sx={{ p: 2 }}>
+					<Typography>Settings</Typography>
+				</Box>
+				<Divider />
+				<Box sx={{ p: 2 }}>
+					<Typography variant="overline">Override rekor endpoint</Typography>
+					<TextField
+						value={localBaseUrl ?? ""}
+						placeholder="https://rekor.sigstore.dev"
+						onChange={handleChangeBaseUrl}
+						fullWidth
+					/>
+				</Box>
+				<Divider sx={{ mt: 2 }} />
+				<Box sx={{ p: 2, display: "flex", gap: 2 }}>
+					<Button
+						onClick={onSave}
+						variant="contained"
+					>
+						Save
+					</Button>
+					<Button onClick={onClose}>Cancel</Button>
+				</Box>
+			</Box>
+		</Drawer>
+	);
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,9 @@
+import SettingsIcon from "@mui/icons-material/Settings";
 import {
 	Box,
 	Container,
 	CssBaseline,
+	IconButton,
 	Link,
 	ThemeProvider,
 	Typography,
@@ -9,10 +11,15 @@ import {
 import type { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
+import { useState } from "react";
+import { RekorClientProvider } from "../modules/api/context";
 import { Explorer } from "../modules/components/Explorer";
+import { Settings } from "../modules/components/Settings";
 import { REKOR_SEARCH_THEME } from "../modules/theme/theme";
 
 const Home: NextPage = () => {
+	const [settingsOpen, setSettingsOpen] = useState(false);
+
 	return (
 		<>
 			<Head>
@@ -57,7 +64,23 @@ const Home: NextPage = () => {
 
 					<Typography variant="h4">Rekor Search</Typography>
 
-					<Box sx={{ width: 198, textAlign: "right" }}>
+					<Box
+						sx={{
+							width: 198,
+							display: "flex",
+							justifyContent: "flex-end",
+							alignItems: "center",
+						}}
+					>
+						<IconButton
+							sx={{ mr: 2 }}
+							aria-label="settings"
+							color="inherit"
+							size="small"
+							onClick={() => setSettingsOpen(true)}
+						>
+							<SettingsIcon />
+						</IconButton>
 						<Link
 							href="https://github.com/chainguard-dev/rekor-search-ui"
 							target="_blank"
@@ -74,6 +97,11 @@ const Home: NextPage = () => {
 						</Link>
 					</Box>
 				</Box>
+
+				<Settings
+					open={settingsOpen}
+					onClose={() => setSettingsOpen(false)}
+				/>
 
 				<Container
 					sx={{
@@ -112,4 +140,9 @@ const Home: NextPage = () => {
 	);
 };
 
-export default Home;
+const Page: NextPage = () => (
+	<RekorClientProvider>
+		<Home />
+	</RekorClientProvider>
+);
+export default Page;


### PR DESCRIPTION
Fixes #31

Introduce a "settings" drawer allowing to override the default Rekor URL.

## Proposed Changes

- 🎁 New settings drawer
- 🎁 Improved error handling for `fetch` failures.
- 🐛 Fixed nested `<a>` links
- 🗑️ Removed dependency on `swr` - it introduced too much complexity when handling URL changes. The `useEffect` code is painfully simple here.